### PR TITLE
Don't check e-shift for NX models that don't support it

### DIFF
--- a/custom_components/jvc_projectors/remote.py
+++ b/custom_components/jvc_projectors/remote.py
@@ -229,8 +229,8 @@ class JVCRemote(RemoteEntity):
                 if not "NZ" in self._model_family:
                     self._lamp_power = self.jvc_client.get_lamp_power()
 
-                # Eshift for NX and NZ only
-                if any(x in self._model_family for x in ["NX", "NZ"]):
+                # Eshift for NX9 and NZ only
+                if any(x in self._model_family for x in ["NX9", "NZ"]):
                     self._eshift = self.jvc_client.get_eshift_mode()
 
                 # NX and NZ process things diff


### PR DESCRIPTION
Only NX9 has e-shift. This call just fails on NX5 (after lengthy retries). Presumably NX7 does the same thing, though I don't have one to test with.