### PR TITLE
performance, reliability, features

### DIFF
--- a/custom_components/jvc_projectors/__init__.py
+++ b/custom_components/jvc_projectors/__init__.py
@@ -1,16 +1,13 @@
 """The JVC Projector integration."""
 
 from __future__ import annotations
-from jvc_projector.jvc_projector import JVCProjectorCoordinator, JVCInput
 import logging
-import asyncio
+from jvc_projector.jvc_projector import JVCProjectorCoordinator, JVCInput
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_HOST,
-    CONF_NAME,
     CONF_PASSWORD,
     CONF_TIMEOUT,
-    CONF_SCAN_INTERVAL,
     Platform,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -32,15 +29,6 @@ async def async_setup_entry(hass, entry):
     options = JVCInput(host, password, port, timeout)
     # Create a coordinator or directly set up your entities with the provided information
     coordinator = JVCProjectorCoordinator(options, _LOGGER)
-    # I dont want to open a connection unless its on because then I can't test
-    # try:
-    #     res = await coordinator.open_connection()
-    #     if not res:
-    #         _LOGGER.error("Error setting up JVC Projector during async_setup_entry")
-    #         return False
-    # except Exception as e:
-    #     _LOGGER.error("Error setting up JVC Projector during async_setup_entry - %s", e)
-    #     return False
 
     # Store the coordinator in hass.data for use by your platform (e.g., remote)
     hass.data[DOMAIN] = coordinator

--- a/custom_components/jvc_projectors/__init__.py
+++ b/custom_components/jvc_projectors/__init__.py
@@ -25,7 +25,6 @@ async def async_setup_entry(hass, entry):
 
     timeout = entry.data.get(CONF_TIMEOUT, 3)
     port = 20554
-    _LOGGER.debug(f"Setting up JVC Projector with host: {host}")
     options = JVCInput(host, password, port, timeout)
     # Create a coordinator or directly set up your entities with the provided information
     coordinator = JVCProjectorCoordinator(options, _LOGGER)

--- a/custom_components/jvc_projectors/config_flow.py
+++ b/custom_components/jvc_projectors/config_flow.py
@@ -58,7 +58,7 @@ class JVCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """return True if the projector connects"""
         try:
             options = JVCInput(host, password, 20554, timeout)
-            coordinator = JVCProjectorCoordinator(options)
+            coordinator = JVCProjectorCoordinator(options, _LOGGER)
             _LOGGER.debug("Validating JVC Projector setup")
             res = await coordinator.open_connection()
             if res:

--- a/custom_components/jvc_projectors/config_flow.py
+++ b/custom_components/jvc_projectors/config_flow.py
@@ -5,10 +5,8 @@ from homeassistant.core import callback
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
-    CONF_PASSWORD,
-    CONF_TIMEOUT,
+    CONF_PASSWORD
 )
-import homeassistant.helpers.config_validation as cv
 from jvc_projector.jvc_projector import JVCProjectorCoordinator, JVCInput
 
 from .const import DOMAIN  # Import the domain constant
@@ -28,7 +26,7 @@ class JVCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = user_input.get(CONF_HOST)
             password = user_input.get(CONF_PASSWORD)
-            timeout = user_input.get(CONF_TIMEOUT, 3)
+            timeout = 5
 
             valid = await self.validate_setup(host, password, timeout)
 
@@ -45,8 +43,7 @@ class JVCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_NAME): str,
                 vol.Required(CONF_HOST): str,
-                vol.Optional(CONF_PASSWORD): str,
-                vol.Optional(CONF_TIMEOUT, default=3): int,
+                vol.Optional(CONF_PASSWORD): str
             }
         )
 
@@ -114,10 +111,7 @@ class JVCOptionsFlow(config_entries.OptionsFlow):
                 vol.Optional(CONF_HOST, default=current_config.get(CONF_HOST)): str,
                 vol.Optional(
                     CONF_PASSWORD, default=current_config.get(CONF_PASSWORD)
-                ): str,
-                vol.Optional(
-                    CONF_TIMEOUT, default=current_config.get(CONF_TIMEOUT, 3)
-                ): int,
+                ): str
             }
         )
 

--- a/custom_components/jvc_projectors/config_flow.py
+++ b/custom_components/jvc_projectors/config_flow.py
@@ -60,12 +60,15 @@ class JVCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             options = JVCInput(host, password, 20554, timeout)
             coordinator = JVCProjectorCoordinator(options)
+            _LOGGER.debug("Validating JVC Projector setup")
             res = await coordinator.open_connection()
             if res:
+                _LOGGER.debug("JVC Projector setup connection worked")
                 await coordinator.close_connection()
+                _LOGGER.debug("JVC Projector setup connection sucessfully closed")
                 return True
         except Exception as e:
-            _LOGGER.error("Error validating JVC Projector setup: %s", e)
+            _LOGGER.error("Error validating JVC Projector setup. Please check host and password: %s", e)
             return False
         return False
 

--- a/custom_components/jvc_projectors/config_flow.py
+++ b/custom_components/jvc_projectors/config_flow.py
@@ -1,13 +1,12 @@
 import voluptuous as vol
 import logging
-from homeassistant import config_entries, core
+from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_TIMEOUT,
-    CONF_SCAN_INTERVAL,
 )
 import homeassistant.helpers.config_validation as cv
 from jvc_projector.jvc_projector import JVCProjectorCoordinator, JVCInput
@@ -68,7 +67,10 @@ class JVCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.debug("JVC Projector setup connection sucessfully closed")
                 return True
         except Exception as e:
-            _LOGGER.error("Error validating JVC Projector setup. Please check host and password: %s", e)
+            _LOGGER.error(
+                "Error validating JVC Projector setup. Please check host and password: %s",
+                e,
+            )
             return False
         return False
 

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.3.48"
+    "pyjvc==4.3.49"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.3.44"
+    "pyjvc==4.3.48"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.3.49"
+    "pyjvc==4.3.50"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.3.1"
+    "pyjvc==4.3.3"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.3.4"
+    "pyjvc==4.3.43"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.3.43"
+    "pyjvc==4.3.44"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.3.3"
+    "pyjvc==4.3.4"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.3.50"
+    "pyjvc==4.3.51"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/iloveicedgreentea/jvc_homeassistant",
   "requirements": [
-    "pyjvc==4.2.1"
+    "pyjvc==4.3.1"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/jvc_projectors/manifest.json
+++ b/custom_components/jvc_projectors/manifest.json
@@ -10,6 +10,7 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
+  "loggers": ["custom_components.jvc_projectors"],
   "codeowners": [
     "@iloveicedgreentea"
   ],

--- a/custom_components/jvc_projectors/remote.py
+++ b/custom_components/jvc_projectors/remote.py
@@ -241,6 +241,7 @@ class JVCRemote(RemoteEntity):
                 # add to the command queue with a single interface
                 await self.command_queue.put((getter, attribute))
                 _LOGGER.debug("added getter %s and attribute %s", getter, attribute)
+                await asyncio.sleep(0.1)
 
     @property
     def should_poll(self):

--- a/custom_components/jvc_projectors/remote.py
+++ b/custom_components/jvc_projectors/remote.py
@@ -350,7 +350,7 @@ class JVCRemote(RemoteEntity):
             _LOGGER.debug("updating state")
             self._state = await self.jvc_client.is_on()
             self.jvc_client.attributes.connection_active = self.jvc_client.writer is not None
-            
+
             if self._state:
                 _LOGGER.debug("getting attributes")
                 attribute_getters.extend(
@@ -362,7 +362,7 @@ class JVCRemote(RemoteEntity):
                 )
                 # determine how to proceed based on above
 
-                if self.jvc_client.attributes.signal_status == "signal":
+                if self.jvc_client.attributes.signal_status is True:
                     attribute_getters.extend(
                         [
                             (self.jvc_client.get_content_type, "content_type"),

--- a/custom_components/jvc_projectors/remote.py
+++ b/custom_components/jvc_projectors/remote.py
@@ -349,6 +349,8 @@ class JVCRemote(RemoteEntity):
             attribute_getters = []
             _LOGGER.debug("updating state")
             self._state = await self.jvc_client.is_on()
+            self.jvc_client.attributes.connection_active = self.jvc_client.writer is not None
+            
             if self._state:
                 _LOGGER.debug("getting attributes")
                 attribute_getters.extend(
@@ -369,7 +371,7 @@ class JVCRemote(RemoteEntity):
                                 "content_type_trans",
                             ),
                             (self.jvc_client.get_input_mode, "input_mode"),
-                            (self.jvc_client.get_anamorphic, "anamophic_mode"),
+                            (self.jvc_client.get_anamorphic, "anamorphic_mode"),
                             (self.jvc_client.get_source_display, "resolution"),
                         ]
                     )

--- a/custom_components/jvc_projectors/strings.json
+++ b/custom_components/jvc_projectors/strings.json
@@ -5,10 +5,14 @@
       "user": {
         "title": "Connect to your JVC Projector",
         "data": {
-          "name": "Name",
-          "host": "Host",
-          "password": "Password",
-          "timeout": "Timeout"
+          "name": "[%key:common::config_flow::data::name%]",
+          "host": "[%key:common::config_flow::data::host%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "name": "Name for your projector",
+          "host": "IP address or hostname of projector",
+          "password": "Optional password if NZ series or higher"
         }
       }
     },


### PR DESCRIPTION
* Improve types for attributes (bools instead of str, etc)
* Try to prevent connection errors if closed and trying to get attribute
* rewrite core logic to make interactions as fast as possible
* make connection more reliable
* [support enabling debug logs in UI ](https://www.home-assistant.io/docs/configuration/troubleshooting/#enabling-debug-logging)

This will now poll the projector every 5 seconds for attributes when its on but in practice it just means it is getting attribute updates non-stop, nearly instantly

It also uses asynchronous priority queues to ensure commands are processed before any attribute updates and preserves the order of commands. This is now guaranteed to be the fastest way to communicate with the unit and any delay is now inherent to JVC's protocol.